### PR TITLE
Fixed possible exception in logging

### DIFF
--- a/HttpTwo/Internal/Logging.cs
+++ b/HttpTwo/Internal/Logging.cs
@@ -39,30 +39,31 @@ namespace HttpTwo.Internal
         public void Info (string format, params object[] args)
         {
             if (Level >= LogLevel.Info)
-                write (string.Format (format, args));
+                write (format, args);
         }
 
         public void Debug (string format, params object[] args)
         {
             if (Level >= LogLevel.Debug)
-                write (string.Format (format, args));
+                write (format, args);
         }
 
         public void Warn (string format, params object[] args)
         {
             if (Level >= LogLevel.Warn)
-                write (string.Format (format, args));
+                write (format, args);
         }
 
         public void Error (string format, params object[] args)
         {
             if (Level >= LogLevel.Error)
-                write (string.Format (format, args));
+                write (format, args);
         }
 
         void write (string format, params object[] args)
         {
-            Console.WriteLine (DateTime.Now.ToString ("hh:MM:ss.fff tt") + ": " + string.Format (format, args));
+            var logMessage = args.Length == 0 ? format : string.Format (format, args);
+            Console.WriteLine (DateTime.Now.ToString ("hh:MM:ss.fff tt") + ": " + logMessage);
         }
     }
 


### PR DESCRIPTION
It's a fix for #10 issue.

Get rid of duplicate string.Format calls. Fix possible FormatExcetpion in two cases:
1) format argument parameter is a string with '{'
2) When initial message  is not a format string but it contains '{'

